### PR TITLE
Constrain Rails version to < 5.2

### DIFF
--- a/activeuuid.gemspec
+++ b/activeuuid.gemspec
@@ -35,6 +35,6 @@ Gem::Specification.new do |s|
     s.add_development_dependency "sqlite3"
   end
 
-  s.add_runtime_dependency "activerecord", ">= 4.0"
+  s.add_runtime_dependency "activerecord", ">= 4.0", "< 5.2"
   s.add_runtime_dependency "uuidtools"
 end


### PR DESCRIPTION
This gem relies on behaviour which has been deprecated in one of 5.x versions, and removed in 5.2.  It simply won't work with newest Rails without major overhaul.  For very now, let's add a version constraint.