### PR TITLE
Fix Rails 4.2 builds

### DIFF
--- a/gemfiles/Rails-4_2.gemfile
+++ b/gemfiles/Rails-4_2.gemfile
@@ -2,7 +2,8 @@ source "http://rubygems.org"
 
 gemspec path: "../"
 
-gem "activerecord", "~> 4.2.0"
+gem "activerecord", "~> 4.2.5"
+gem "mysql2", "~> 0.4.0", platforms: %i[mri rbx]
 
 gem "codecov", require: false, group: :test
 gem "simplecov", require: false, group: :test


### PR DESCRIPTION
Install compatible version of mysql2 gem, according to https://github.com/brianmario/mysql2/issues/743. Also, bump requirement for Rails 4.2.x to at least 4.2.5.