### PR TITLE
Drop support for Rails older than 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,6 @@ matrix:
     - rvm: jruby-9.1.15.0
       gemfile: gemfiles/Rails-5_1.gemfile
   exclude:
-    - rvm: 2.3.6
-      gemfile: gemfiles/Rails-3_1.gemfile
-    - rvm: jruby
-      gemfile: gemfiles/Rails-3_1.gemfile
-      env: DB=postgresql
-    - rvm: 2.3.6
-      gemfile: gemfiles/Rails-3_2.gemfile
     - rvm: 2.4.3
       gemfile: gemfiles/Rails-4_0.gemfile
     - rvm: 2.4.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ rvm:
 
 gemfile:
   - Gemfile
-  - gemfiles/Rails-4_0.gemfile
-  - gemfiles/Rails-4_1.gemfile
   - gemfiles/Rails-4_2.gemfile
   - gemfiles/Rails-5_0.gemfile
   - gemfiles/Rails-5_1.gemfile
@@ -27,19 +25,8 @@ matrix:
     - rvm: jruby-9.1.15.0
       gemfile: Gemfile
     - rvm: jruby-9.1.15.0
-      gemfile: gemfiles/Rails-4_0.gemfile
-    - rvm: jruby-9.1.15.0
-      gemfile: gemfiles/Rails-4_1.gemfile
-    - rvm: jruby-9.1.15.0
       gemfile: gemfiles/Rails-4_2.gemfile
     - rvm: jruby-9.1.15.0
       gemfile: gemfiles/Rails-5_0.gemfile
     - rvm: jruby-9.1.15.0
       gemfile: gemfiles/Rails-5_1.gemfile
-  exclude:
-    - rvm: 2.4.3
-      gemfile: gemfiles/Rails-4_0.gemfile
-    - rvm: 2.4.3
-      gemfile: gemfiles/Rails-4_1.gemfile
-    - rvm: 2.4.3
-      gemfile: gemfiles/Rails-4_2.gemfile

--- a/activeuuid.gemspec
+++ b/activeuuid.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |s|
     s.add_development_dependency "sqlite3"
   end
 
-  s.add_runtime_dependency "activerecord", ">= 4.0", "< 5.2"
+  s.add_runtime_dependency "activerecord", ">= 4.2", "< 5.2"
   s.add_runtime_dependency "uuidtools"
 end

--- a/gemfiles/Rails-4_0.gemfile
+++ b/gemfiles/Rails-4_0.gemfile
@@ -1,9 +1,0 @@
-source "http://rubygems.org"
-
-gemspec path: "../"
-
-gem "activerecord", "~> 4.0.0"
-gem "mysql2", "~> 0.3.21", "~> 0.3.21", platforms: %i[mri rbx]
-
-gem "codecov", require: false, group: :test
-gem "simplecov", require: false, group: :test

--- a/gemfiles/Rails-4_1.gemfile
+++ b/gemfiles/Rails-4_1.gemfile
@@ -1,9 +1,0 @@
-source "http://rubygems.org"
-
-gemspec path: "../"
-
-gem "activerecord", "~> 4.1.0"
-gem "mysql2", "~> 0.3.21", platforms: %i[mri rbx]
-
-gem "codecov", require: false, group: :test
-gem "simplecov", require: false, group: :test


### PR DESCRIPTION
From now, this gem is intended to rely on ActiveRecord's attributes API, which has been introduced in Rails 4.2.

Old implementation (including hacks specific for Rails < 4.2) is kept for now. It will be rewritten soon.