### PR TITLE
Force creation of test database tables

### DIFF
--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -1,5 +1,5 @@
 ActiveRecord::Schema.define do
-  create_table :articles do |t|
+  create_table :articles, force: true do |t|
     t.string :title
     t.text :body
     t.column :some_array, :integer, array: true
@@ -7,7 +7,7 @@ ActiveRecord::Schema.define do
     t.timestamps
   end
 
-  create_table :uuid_articles, id: false do |t|
+  create_table :uuid_articles, id: false, force: true do |t|
     t.uuid :id, primary_key: true
     t.string :title
     t.text :body


### PR DESCRIPTION
Running tests in development is much easier when one doesn't need to drop tables manually before running RSpec.