### PR TITLE
Relax PostgreSQL dependency

### DIFF
--- a/activeuuid.gemspec
+++ b/activeuuid.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency "activerecord-jdbcsqlite3-adapter"
   else
     s.add_development_dependency "mysql2"
-    s.add_development_dependency "pg", "< 1.0"
+    s.add_development_dependency "pg"
     s.add_development_dependency "sqlite3"
   end
 


### PR DESCRIPTION
Old implementation has been removed, and since then everything works with recent versions of `pg` gem. Fixes #7.