### PR TITLE
Make monkey patches optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ matrix:
       env: DB=mysql
     - gemfile: gemfiles/Rails-5_0.gemfile
       env: DB=postgresql
+    # Without monkey patches
+    - env: DB=sqlite3 NO_PATCHES=1
+    - env: DB=mysql NO_PATCHES=1
+    - env: DB=postgresql NO_PATCHES=1
   allow_failures:
     - gemfile: gemfiles/Rails-head.gemfile
     - rvm: jruby

--- a/lib/active_uuid.rb
+++ b/lib/active_uuid.rb
@@ -1,8 +1,8 @@
 require "active_uuid/version"
 require "active_uuid/utils"
 require "active_uuid/attribute_type"
+require "active_uuid/connection_patches"
 require "active_uuid/model"
-require "active_uuid/patches"
 require "active_uuid/railtie" if defined?(Rails::Railtie)
 require "pp"
 
@@ -12,4 +12,4 @@ module ActiveUUID
   end
 end
 
-ActiveUUID::Patches.apply!
+ActiveUUID::ConnectionPatches.apply!

--- a/lib/active_uuid.rb
+++ b/lib/active_uuid.rb
@@ -11,5 +11,3 @@ module ActiveUUID
     delegate :quote_as_binary, to: Utils
   end
 end
-
-ActiveUUID::ConnectionPatches.apply!

--- a/lib/active_uuid.rb
+++ b/lib/active_uuid.rb
@@ -1,7 +1,6 @@
 require "active_uuid/version"
 require "active_uuid/utils"
 require "active_uuid/attribute_type"
-require "active_uuid/connection_patches"
 require "active_uuid/model"
 require "active_uuid/railtie" if defined?(Rails::Railtie)
 require "pp"

--- a/lib/active_uuid/all.rb
+++ b/lib/active_uuid/all.rb
@@ -1,0 +1,2 @@
+require_relative "../active_uuid"
+require_relative "connection_patches"

--- a/lib/active_uuid/connection_patches.rb
+++ b/lib/active_uuid/connection_patches.rb
@@ -3,7 +3,7 @@ require "active_support/concern"
 
 
 module ActiveUUID
-  module Patches
+  module ConnectionPatches
     module Migrations
       def uuid(*column_names)
         options = column_names.extract_options!

--- a/lib/active_uuid/connection_patches.rb
+++ b/lib/active_uuid/connection_patches.rb
@@ -55,3 +55,5 @@ module ActiveUUID
     end
   end
 end
+
+ActiveUUID::ConnectionPatches.apply!

--- a/spec/integration/migrations_spec.rb
+++ b/spec/integration/migrations_spec.rb
@@ -1,6 +1,12 @@
 require "spec_helper"
 
 RSpec.describe "migration methods" do
+  before do
+    if ENV.fetch("NO_PATCHES", false)
+      skip "Migrations are unavailable without monkey patching"
+    end
+  end
+
   shared_examples "active record examples" do |can_change_column_to_uuid: true|
     let(:connection) { ActiveRecord::Base.connection }
     let(:table_name) { :test_uuid_field_creation }

--- a/spec/integration/no_patches_spec.rb
+++ b/spec/integration/no_patches_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+RSpec.describe "without monkey patches" do
+  before do
+    unless ENV.fetch("NO_PATCHES", false)
+      skip "Monkey patching is enabled in this build"
+    end
+  end
+
+  it "does not patch ActiveRecord connection" do
+    db_conn = ActiveRecord::Base.connection
+    db_conn_modules = db_conn.singleton_class.ancestors
+
+    expect(db_conn_modules).to all(satisfy { |m| /ActiveUUID/ !~ m.name })
+  end
+
+  it "does not patch Table class" do
+    table_modules = ActiveRecord::ConnectionAdapters::Table.ancestors
+    expect(table_modules).to all(satisfy { |m| /ActiveUUID/ !~ m.name })
+  end
+
+  it "does not patch TableDefinition class" do
+    table_modules = ActiveRecord::ConnectionAdapters::TableDefinition.ancestors
+    expect(table_modules).to all(satisfy { |m| /ActiveUUID/ !~ m.name })
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ ENV["DB"] ||= "sqlite3"
 require "bundler/setup"
 Bundler.require :development
 
-require "active_uuid"
+require "active_uuid/all"
 
 ActiveRecord::Base.logger =
   Logger.new(File.expand_path("../log/test.log", __dir__))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,11 @@ ENV["DB"] ||= "sqlite3"
 require "bundler/setup"
 Bundler.require :development
 
-require "active_uuid/all"
+if ENV.fetch("NO_PATCHES", false)
+  require "active_uuid"
+else
+  require "active_uuid/all"
+end
 
 ActiveRecord::Base.logger =
   Logger.new(File.expand_path("../log/test.log", __dir__))


### PR DESCRIPTION
Neither core feature of this gem currently requires monkey patching. On the other hand, a very convenient `#uuid` method for database schemas and migrations relies on monkey patching of database connection.

It is prudent to avoid monkey patching when it is not necessary, therefore since this pull request it is up to users whether to load these patches or not:

* in order to avoid monkey patching, they should require `active_uuid`
* in order to enable monkey patches and all features, they should require `active_uuid/all`