### PR TITLE
State programming language in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: xenial
+language: ruby
 
 services:
   - mysql


### PR DESCRIPTION
It defaults to Ruby, but it's a good idea to be explicit.