### PR TITLE
Improve table definition method

### DIFF
--- a/lib/active_uuid/connection_patches.rb
+++ b/lib/active_uuid/connection_patches.rb
@@ -4,7 +4,7 @@ require "active_support/concern"
 
 module ActiveUUID
   module ConnectionPatches
-    module Migrations
+    module ColumnMethods
       def uuid(*column_names)
         options = column_names.extract_options!
         column_names.each do |name|
@@ -40,8 +40,8 @@ module ActiveUUID
 
         aca = ActiveRecord::ConnectionAdapters
 
-        aca::Table.send           :include, Migrations if defined? aca::Table
-        aca::TableDefinition.send :include, Migrations if defined? aca::TableDefinition
+        aca::Table.send           :include, ColumnMethods if defined? aca::Table
+        aca::TableDefinition.send :include, ColumnMethods if defined? aca::TableDefinition
 
         aca::MysqlAdapter.send      :prepend, Quoting           if defined? aca::MysqlAdapter
         aca::Mysql2Adapter.send     :prepend, Quoting           if defined? aca::Mysql2Adapter

--- a/lib/active_uuid/connection_patches.rb
+++ b/lib/active_uuid/connection_patches.rb
@@ -5,12 +5,8 @@ require "active_support/concern"
 module ActiveUUID
   module ConnectionPatches
     module ColumnMethods
-      def uuid(*column_names)
-        options = column_names.extract_options!
-        column_names.each do |name|
-          type = ActiveRecord::Base.connection.adapter_name.casecmp("postgresql").zero? ? "uuid" : "binary(16)"
-          column(name, "#{type}#{' PRIMARY KEY' if options.delete(:primary_key)}", options)
-        end
+      def uuid(*args, **options)
+        args.each { |name| column(name, :uuid, options) }
       end
     end
 


### PR DESCRIPTION
Don't use raw SQL in `#uuid` schema method.  It is meant to work on higher level of abstraction.  Specific SQL type is provided by respective adapter in `#native_database_types` method.