### PR TITLE
Cache gems in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 dist: xenial
 language: ruby
 
+cache:
+  bundler: true
+
 services:
   - mysql
   - postgresql


### PR DESCRIPTION
Ci builds are now somewhat faster. Not greatly, but definitely noticeably.