### PR TITLE
Delete dead code

### DIFF
--- a/lib/active_uuid/model.rb
+++ b/lib/active_uuid/model.rb
@@ -26,13 +26,6 @@ module ActiveUUID
         self._uuid_generator = generator_name
       end
 
-      def uuids(*_attributes)
-        ActiveSupport::Deprecation.warn <<-EOS
-          ActiveUUID detects uuid columns independently.
-          There is no more need to use uuid method.
-        EOS
-      end
-
       def uuid_columns
         @uuid_columns ||= columns.select { |c| c.type == :uuid }.map(&:name)
       end

--- a/lib/active_uuid/model.rb
+++ b/lib/active_uuid/model.rb
@@ -8,7 +8,6 @@ module ActiveUUID
       class_attribute :_uuid_generator, instance_writer: false
       self._uuid_generator = :random
 
-      singleton_class.prepend Instantiation
       before_create :generate_uuids_if_needed
     end
 
@@ -28,16 +27,6 @@ module ActiveUUID
 
       def uuid_columns
         @uuid_columns ||= columns.select { |c| c.type == :uuid }.map(&:name)
-      end
-    end
-
-    module Instantiation
-      def instantiate(record, _record_models = nil)
-        uuid_columns.each do |uuid_column|
-          record[uuid_column] = UUIDTools::UUID.serialize(record[uuid_column]).to_s if record[uuid_column]
-        end
-
-        super(record)
       end
     end
 

--- a/lib/active_uuid/model.rb
+++ b/lib/active_uuid/model.rb
@@ -24,10 +24,6 @@ module ActiveUUID
       def uuid_generator(generator_name)
         self._uuid_generator = generator_name
       end
-
-      def uuid_columns
-        @uuid_columns ||= columns.select { |c| c.type == :uuid }.map(&:name)
-      end
     end
 
     def create_uuid


### PR DESCRIPTION
Wipe unnecessary (and untested, and possibly buggy) methods and modules from `ActiveUUID::Model`.