### PR TITLE
Refactor ActiveRecord attribute types (use subclasses instead of parametrized initializer)

### DIFF
--- a/lib/active_uuid.rb
+++ b/lib/active_uuid.rb
@@ -1,7 +1,7 @@
 require "active_uuid/version"
 require "active_uuid/utils"
-require "active_uuid/attribute_type"
 require "active_uuid/model"
+require "active_uuid/type"
 require "active_uuid/railtie" if defined?(Rails::Railtie)
 require "pp"
 

--- a/lib/active_uuid/attribute_type.rb
+++ b/lib/active_uuid/attribute_type.rb
@@ -6,58 +6,58 @@ module ActiveUUID
   # See docs for +::ActiveRecord::Attributes::ClassMethods#attribute+ for usage.
   # See docs for +::ActiveRecord::Type::Value+ for meaning of overriden methods.
   class AttributeType < ::ActiveRecord::Type::Value
-    attr_reader :storage_type
+      attr_reader :storage_type
 
-    delegate :cast_to_uuid, to: ActiveUUID::Utils
-    delegate :serialize, :deserialize, to: :storage_type, prefix: :s
+      delegate :cast_to_uuid, to: ActiveUUID::Utils
+      delegate :serialize, :deserialize, to: :storage_type, prefix: :s
 
-    def initialize(storage_mode)
-      @storage_type = instantiate_storage(storage_mode)
-    end
-
-    # Converts UUID or its string representation into a binary value (see
-    # super).
-    def serialize(value)
-      s_serialize(cast_to_uuid(value))
-    end
-
-    # Converts binary values into UUIDs.
-    def deserialize(value)
-      cast_to_uuid(s_deserialize(value))
-    end
-
-    # Converts strings into UUIDs on user input assignment, called internally
-    # from #cast.
-    def cast_value(value)
-      cast_to_uuid(value)
-    end
-
-    private
-
-    # Returns a new instance of attribute type appropriate for requested storage
-    # mode.
-    def instantiate_storage(storage_mode)
-      case storage_mode
-      when :binary then BinaryStorage.new
-      when :string then StringStorage.new
-      else
-        raise ArgumentError, "Incorrect storage mode.  It must be " +
-          "either :binary or :string, but #{storage_mode.inspect} was passed."
+      def initialize(storage_mode)
+        @storage_type = instantiate_storage(storage_mode)
       end
-    end
 
-    # Wrapper for `ActiveRecord::Type::Binary` which (de)serializes UUIDs.
-    class BinaryStorage < ::ActiveRecord::Type::Binary
-      def serialize(uuid_or_nil)
-        super(uuid_or_nil&.raw)
+      # Converts UUID or its string representation into a binary value (see
+      # super).
+      def serialize(value)
+        s_serialize(cast_to_uuid(value))
       end
-    end
 
-    # Wrapper for `ActiveModel::Type::String` which (de)serializes UUIDs.
-    class StringStorage < ActiveRecord::Type::String
-      def serialize(uuid_or_nil)
-        super(uuid_or_nil&.to_s)
+      # Converts binary values into UUIDs.
+      def deserialize(value)
+        cast_to_uuid(s_deserialize(value))
       end
-    end
+
+      # Converts strings into UUIDs on user input assignment, called internally
+      # from #cast.
+      def cast_value(value)
+        cast_to_uuid(value)
+      end
+
+      private
+
+      # Returns a new instance of attribute type appropriate for requested storage
+      # mode.
+      def instantiate_storage(storage_mode)
+        case storage_mode
+        when :binary then BinaryStorage.new
+        when :string then StringStorage.new
+        else
+          raise ArgumentError, "Incorrect storage mode.  It must be " +
+            "either :binary or :string, but #{storage_mode.inspect} was passed."
+        end
+      end
+
+      # Wrapper for `ActiveRecord::Type::Binary` which (de)serializes UUIDs.
+      class BinaryStorage < ::ActiveRecord::Type::Binary
+        def serialize(uuid_or_nil)
+          super(uuid_or_nil&.raw)
+        end
+      end
+
+      # Wrapper for `ActiveModel::Type::String` which (de)serializes UUIDs.
+      class StringStorage < ActiveRecord::Type::String
+        def serialize(uuid_or_nil)
+          super(uuid_or_nil&.to_s)
+        end
+      end
   end
 end

--- a/lib/active_uuid/attribute_type.rb
+++ b/lib/active_uuid/attribute_type.rb
@@ -5,20 +5,15 @@ module ActiveUUID
   #
   # See docs for +::ActiveRecord::Attributes::ClassMethods#attribute+ for usage.
   # See docs for +::ActiveRecord::Type::Value+ for meaning of overriden methods.
-  class AttributeType < ::ActiveRecord::Type::Value
+  module AttributeType
+    class Base < ::ActiveRecord::Type::Value
       attr_reader :storage_type
 
       delegate :cast_to_uuid, to: ActiveUUID::Utils
       delegate :serialize, :deserialize, to: :storage_type, prefix: :s
 
-      def initialize(storage_mode)
-        @storage_type = instantiate_storage(storage_mode)
-      end
-
-      # Converts UUID or its string representation into a binary value (see
-      # super).
-      def serialize(value)
-        s_serialize(cast_to_uuid(value))
+      def initialize
+        @storage_type = instantiate_storage
       end
 
       # Converts binary values into UUIDs.
@@ -31,33 +26,26 @@ module ActiveUUID
       def cast_value(value)
         cast_to_uuid(value)
       end
+    end
 
-      private
-
-      # Returns a new instance of attribute type appropriate for requested storage
-      # mode.
-      def instantiate_storage(storage_mode)
-        case storage_mode
-        when :binary then BinaryStorage.new
-        when :string then StringStorage.new
-        else
-          raise ArgumentError, "Incorrect storage mode.  It must be " +
-            "either :binary or :string, but #{storage_mode.inspect} was passed."
-        end
+    class BinaryUUID < Base
+      def instantiate_storage
+        ::ActiveRecord::Type::Binary.new
       end
 
-      # Wrapper for `ActiveRecord::Type::Binary` which (de)serializes UUIDs.
-      class BinaryStorage < ::ActiveRecord::Type::Binary
-        def serialize(uuid_or_nil)
-          super(uuid_or_nil&.raw)
-        end
+      def serialize(value)
+        s_serialize(cast_to_uuid(value)&.raw)
+      end
+    end
+
+    class StringUUID < Base
+      def instantiate_storage
+        ::ActiveRecord::Type::String.new
       end
 
-      # Wrapper for `ActiveModel::Type::String` which (de)serializes UUIDs.
-      class StringStorage < ActiveRecord::Type::String
-        def serialize(uuid_or_nil)
-          super(uuid_or_nil&.to_s)
-        end
+      def serialize(value)
+        s_serialize(cast_to_uuid(value)&.to_s)
       end
+    end
   end
 end

--- a/lib/active_uuid/model.rb
+++ b/lib/active_uuid/model.rb
@@ -1,3 +1,5 @@
+require "active_support"
+
 module ActiveUUID
   module Model
     extend ActiveSupport::Concern

--- a/lib/active_uuid/model.rb
+++ b/lib/active_uuid/model.rb
@@ -44,7 +44,7 @@ module ActiveUUID
     def generate_uuids_if_needed
       primary_key = self.class.primary_key
       primary_key_attribute_type = self.class.type_for_attribute(primary_key)
-      if ::ActiveUUID::AttributeType::Base === primary_key_attribute_type
+      if ::ActiveUUID::Type::Base === primary_key_attribute_type
         send("#{primary_key}=", create_uuid) unless send("#{primary_key}?")
       end
     end

--- a/lib/active_uuid/model.rb
+++ b/lib/active_uuid/model.rb
@@ -44,7 +44,7 @@ module ActiveUUID
     def generate_uuids_if_needed
       primary_key = self.class.primary_key
       primary_key_attribute_type = self.class.type_for_attribute(primary_key)
-      if ::ActiveUUID::AttributeType === primary_key_attribute_type
+      if ::ActiveUUID::AttributeType::Base === primary_key_attribute_type
         send("#{primary_key}=", create_uuid) unless send("#{primary_key}?")
       end
     end

--- a/lib/active_uuid/type.rb
+++ b/lib/active_uuid/type.rb
@@ -5,7 +5,7 @@ module ActiveUUID
   #
   # See docs for +::ActiveRecord::Attributes::ClassMethods#attribute+ for usage.
   # See docs for +::ActiveRecord::Type::Value+ for meaning of overriden methods.
-  module AttributeType
+  module Type
     class Base < ::ActiveRecord::Type::Value
       attr_reader :storage_type
 

--- a/spec/integration/examples_for_uuid_models.rb
+++ b/spec/integration/examples_for_uuid_models.rb
@@ -59,7 +59,7 @@ RSpec.shared_examples "model with UUIDs" do
     let(:uuid) { UUIDTools::UUID.random_create }
 
     it "has proper ActiveRecord type" do
-      expect(attr_type).to be_kind_of(ActiveUUID::AttributeType)
+      expect(attr_type).to be_kind_of(ActiveUUID::AttributeType::Base)
     end
 
     it "allows to assign UUID instance" do

--- a/spec/integration/examples_for_uuid_models.rb
+++ b/spec/integration/examples_for_uuid_models.rb
@@ -59,7 +59,7 @@ RSpec.shared_examples "model with UUIDs" do
     let(:uuid) { UUIDTools::UUID.random_create }
 
     it "has proper ActiveRecord type" do
-      expect(attr_type).to be_kind_of(ActiveUUID::AttributeType::Base)
+      expect(attr_type).to be_kind_of(ActiveUUID::Type::Base)
     end
 
     it "allows to assign UUID instance" do

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -14,13 +14,14 @@ end
 # - NativeUuidArticleWithNamespace
 %w[binary string native].each do |table_prefix|
   table_name = "#{table_prefix}_uuid_articles"
-  storage_mode = table_prefix == "binary" ? :binary : :string
+  attribute_type_name = table_prefix == "binary" ? "BinaryUUID" : "StringUUID"
+  attribute_type = ActiveUUID::AttributeType.const_get(attribute_type_name)
 
   regular_class = Class.new(ActiveRecord::Base) do
     include ActiveUUID::Model
     self.table_name = table_name
-    attribute :id, ActiveUUID::AttributeType.new(storage_mode)
-    attribute :another_uuid, ActiveUUID::AttributeType.new(storage_mode)
+    attribute :id, attribute_type.new
+    attribute :another_uuid, attribute_type.new
   end
 
   natural_key_class = Class.new(regular_class) do

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -15,7 +15,7 @@ end
 %w[binary string native].each do |table_prefix|
   table_name = "#{table_prefix}_uuid_articles"
   attribute_type_name = table_prefix == "binary" ? "BinaryUUID" : "StringUUID"
-  attribute_type = ActiveUUID::AttributeType.const_get(attribute_type_name)
+  attribute_type = ActiveUUID::Type.const_get(attribute_type_name)
 
   regular_class = Class.new(ActiveRecord::Base) do
     include ActiveUUID::Model

--- a/spec/unit/attribute_type_spec.rb
+++ b/spec/unit/attribute_type_spec.rb
@@ -2,13 +2,13 @@ require "spec_helper"
 
 # Type assertions are necessary because you can't tell UUID and String apart
 # with regular ==.
-RSpec.describe ActiveUUID::AttributeType do
+RSpec.describe ActiveUUID::Type do
   let(:uuid) { UUIDTools::UUID.parse(hex_with_dashes) }
   let(:hex_with_dashes) { "472b22d4-9fa3-45c4-86cd-2f2cdf77d485" }
   let(:hex_without_dashes) { hex_with_dashes.delete("-").upcase }
   let(:binary_string) { uuid.raw }
 
-  describe ActiveUUID::AttributeType::BinaryUUID do
+  describe ActiveUUID::Type::BinaryUUID do
     let(:instance) { described_class.new }
 
     describe "#cast" do
@@ -32,7 +32,7 @@ RSpec.describe ActiveUUID::AttributeType do
     end
   end
 
-  describe ActiveUUID::AttributeType::StringUUID do
+  describe ActiveUUID::Type::StringUUID do
     let(:instance) { described_class.new }
 
     describe "#cast" do

--- a/spec/unit/attribute_type_spec.rb
+++ b/spec/unit/attribute_type_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe ActiveUUID::AttributeType do
   let(:hex_without_dashes) { hex_with_dashes.delete("-").upcase }
   let(:binary_string) { uuid.raw }
 
-  context "with binary storage" do
-    let(:instance) { described_class.new(:binary) }
+  describe ActiveUUID::AttributeType::BinaryUUID do
+    let(:instance) { described_class.new }
 
     describe "#cast" do
       subject { instance.method(:cast) }
@@ -32,8 +32,8 @@ RSpec.describe ActiveUUID::AttributeType do
     end
   end
 
-  context "with string storage" do
-    let(:instance) { described_class.new(:string) }
+  describe ActiveUUID::AttributeType::StringUUID do
+    let(:instance) { described_class.new }
 
     describe "#cast" do
       subject { instance.method(:cast) }


### PR DESCRIPTION
Define a separate class for each UUID serialization mode, instead of parametrized initializer used previously.

Because of this change, this classes are now compatible with `ActiveRecord::Type#register` method, which does not pass any arguments to constructors. Apart from that, implementation is simpler, and easier to read.