### PR TITLE
Add :uuid to ActiveRecord's type registry

### DIFF
--- a/lib/active_uuid/all.rb
+++ b/lib/active_uuid/all.rb
@@ -1,2 +1,3 @@
 require_relative "../active_uuid"
 require_relative "connection_patches"
+require_relative "register_types"

--- a/lib/active_uuid/register_types.rb
+++ b/lib/active_uuid/register_types.rb
@@ -1,0 +1,18 @@
+ActiveRecord::Type.register(
+  :uuid,
+  ::ActiveUUID::Type::BinaryUUID,
+  adapter: :mysql2,
+)
+
+ActiveRecord::Type.register(
+  :uuid,
+  ::ActiveUUID::Type::StringUUID,
+  adapter: :postgresql,
+  override: true,
+)
+
+ActiveRecord::Type.register(
+  :uuid,
+  ::ActiveUUID::Type::BinaryUUID,
+  adapter: :sqlite,
+)

--- a/spec/integration/registered_type_spec.rb
+++ b/spec/integration/registered_type_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+Dir["#{__dir__}/examples_*.rb"].each { |f| require f }
+
+RSpec.describe "using registered :uuid type" do
+  before do
+    if ENV.fetch("NO_PATCHES", false)
+      skip "Attribute types are not registered when monkey patching is disabled"
+    end
+  end
+
+  include_examples "model with UUIDs" do
+    let(:model) { RegisteredUuidTypeArticle }
+
+    unless ENV["DB"] == "postgresql"
+      let(:quoted_article_id) { ActiveUUID.quote_as_binary(article.id) }
+    end
+  end
+end

--- a/spec/support/fabricators.rb
+++ b/spec/support/fabricators.rb
@@ -5,7 +5,7 @@ fab_names = uuid_fab_prefixes.product(uuid_fab_suffixes).map do |p, s|
   [p, "uuid_article", s].compact.join("_").to_sym
 end
 
-fab_names.push(:article)
+fab_names.push(:article, :registered_uuid_type_article)
 
 fab_names.each do |fab_name|
   Fabricator(fab_name) do

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -39,3 +39,16 @@ end
   key_with_namescape_class_name = "#{regular_class_name}WithNamespace"
   Object.const_set key_with_namescape_class_name, key_with_namescape_class
 end
+
+class RegisteredUuidTypeArticle < ActiveRecord::Base
+  include ActiveUUID::Model
+
+  if ENV["DB"] == "postgresql"
+    self.table_name = "native_uuid_articles"
+  else
+    self.table_name = "binary_uuid_articles"
+  end
+
+  attribute :id, :uuid
+  attribute :another_uuid, :uuid
+end


### PR DESCRIPTION
Register ActiveUUID's attribute types in the type registry, so that users can simply refer these types with an `:uuid` symbol.