### PR TITLE
Write RDoc for all rewritten code

### DIFF
--- a/lib/active_uuid/model.rb
+++ b/lib/active_uuid/model.rb
@@ -1,6 +1,7 @@
 require "active_support"
 
 module ActiveUUID
+  # Include this module into all models which are meant to store UUIDs.
   module Model
     extend ActiveSupport::Concern
 

--- a/lib/active_uuid/utils.rb
+++ b/lib/active_uuid/utils.rb
@@ -5,6 +5,22 @@ module ActiveUUID
   module Utils
     module_function
 
+    # Casts +value+ to +UUIDTools::UUID+.
+    #
+    # When an instance of +UUIDTools::UUID+ or +nil+ is given, then this method
+    # returns that argument.  When a +String+ is given, then it is parsed,
+    # and respective instance of UUIDTools::UUID is returned.
+    #
+    # A variety of string formats is recognized:
+    #
+    # - 36 characters long strings (hexadecimal number interpolated with dashes)
+    # - 32 characters long strings (hexadecimal number without dashes)
+    # - 16 bytes long strings (binary representation of UUID)
+    #
+    # @param value [UUIDTools::UUID, String, nil] value to be casted
+    #   to +UUIDTools::UUID+.
+    # @raise [ArgumentError] argument cannot be casted to UUIDTools::UUID.
+    # @return [UUIDTools::UUID, nil] respective UUID instance or nil.
     def cast_to_uuid(value)
       case value
       when UUIDTools::UUID, nil
@@ -17,11 +33,28 @@ module ActiveUUID
       end
     end
 
+    # Casts UUID to binary and quotes it, so that it can be used in SQL query
+    # interpolation.
+    #
+    #   model.where("id = ?", ActiveUUID.quote_as_binary(some_uuid))
+    #
+    # This method is unable to determine the correct attribute type.
+    # It always casts UUIDs to their binary form, which may be unwanted in some
+    # contexts, i.e. in case of UUIDs which are meant to be serialized as
+    # strings or as Postgres' native +UUID+ data type.  Due to this fact,
+    # it is generally recommended to avoid SQL query interpolation if possible.
+    #
+    # @param value [UUIDTools::UUID, String, nil] UUID or its representation
+    #   to be quoted.
+    # @raise [ArgumentError] see cast_to_uuid.
+    # @return [::ActiveRecord::Type::Binary::Data, nil] a binary value which
+    #   can be used in SQL queries.
     def quote_as_binary(value)
       uuid = cast_to_uuid(value)
       uuid && ::ActiveRecord::Type::Binary::Data.new(uuid.raw)
     end
 
+    # :nodoc:
     # Unfortunately, UUIDTools is missing some validations, hence we have to do
     # them here.
     #


### PR DESCRIPTION
Some parts of API are still poorly documented. Typically these ones which haven't been thoroughly changed since forking yet.