### PR TITLE
Extract some setup from spec helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,28 +17,9 @@ else
   require "active_uuid/all"
 end
 
-ActiveRecord::Base.logger =
-  Logger.new(File.expand_path("../log/test.log", __dir__))
-ActiveRecord::Base.configurations =
-  YAML::safe_load(File.read(File.expand_path("support/database.yml", __dir__)))
-ActiveRecord::Base.establish_connection(ENV["DB"].to_sym)
-
 Dir[File.expand_path("support/**/*.rb", __dir__)].sort.each { |f| require f }
 
 RSpec.configure do |config|
-  config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation)
-    DatabaseCleaner.strategy = :transaction
-  end
-
-  config.before(:each) do
-    DatabaseCleaner.start
-  end
-
-  config.after(:each) do
-    DatabaseCleaner.clean
-  end
-
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods

--- a/spec/support/0_logger.rb
+++ b/spec/support/0_logger.rb
@@ -1,0 +1,2 @@
+log_path = File.expand_path("../../log/test.log", __dir__)
+ActiveRecord::Base.logger = Logger.new(log_path)

--- a/spec/support/1_db_connection.rb
+++ b/spec/support/1_db_connection.rb
@@ -1,0 +1,3 @@
+db_config_path = File.expand_path("database.yml", __dir__)
+ActiveRecord::Base.configurations = YAML::safe_load(File.read(db_config_path))
+ActiveRecord::Base.establish_connection(ENV["DB"].to_sym)

--- a/spec/support/2_db_cleaner.rb
+++ b/spec/support/2_db_cleaner.rb
@@ -1,0 +1,14 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+end


### PR DESCRIPTION
Move ActiveRecord and DatabaseCleaner configuration to support file.  This will reduce clutter in spec helper, and also make re-using things outside RSpec possible.