### PR TITLE
Write usage examples for common use cases

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,4 +12,16 @@ Rake::Application.send :include, TempFixForRakeLastComment
 
 RSpec::Core::RakeTask.new(:spec)
 
-task default: :spec
+task default: :test
+
+task test: [:spec, :examples]
+
+task :examples do
+  Dir.glob("examples/**.rb").sort.each do |example|
+    example_name = File.basename(example, ".rb").tr("_", " ")
+    puts "-" * 40
+    puts "Testing example: #{example_name}"
+    system "ruby", example
+    puts "-" * 40
+  end
+end

--- a/activeuuid.gemspec
+++ b/activeuuid.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.5"
   s.add_development_dependency "rspec-its"
+  s.add_development_dependency "solid_assert", "~> 1.0"
 
   if RUBY_ENGINE == "jruby"
     s.add_development_dependency "activerecord-jdbcmysql-adapter"

--- a/examples/name_based_uuids.rb
+++ b/examples/name_based_uuids.rb
@@ -1,0 +1,92 @@
+# Name-based UUIDs (version 5) are generated deterministically basing
+# on attribute values and namespace.
+
+ENV["DB"] ||= "sqlite3"
+
+require "bundler/setup"
+Bundler.require :development
+
+require "active_uuid"
+require_relative "../spec/support/0_logger"
+require_relative "../spec/support/1_db_connection"
+
+#### SCHEMA ####
+
+ActiveRecord::Schema.define do
+  create_table :works, id: false, force: true do |t|
+    t.string :id, limit: 36, primary_key: true, index: true
+    t.string :author_id, limit: 36, index: true
+    t.string :title
+    t.timestamps
+  end
+
+  create_table :authors, id: false, force: true do |t|
+    t.string :id, limit: 36, primary_key: true, index: true
+    t.string :name
+    t.timestamps
+  end
+end
+
+#### MODELS ####
+
+class Work < ActiveRecord::Base
+  include ActiveUUID::Model
+  attribute :id, ActiveUUID::Type::StringUUID.new
+  attribute :author_id, ActiveUUID::Type::StringUUID.new
+  belongs_to :author
+  natural_key :author_id, :title
+  uuid_namespace "a6908e1e-5493-4c55-a11d-cd8445654de6"
+end
+
+class Author < ActiveRecord::Base
+  include ActiveUUID::Model
+  attribute :id, ActiveUUID::Type::StringUUID.new
+  has_many :works
+  natural_key :name
+end
+
+#### PROOF ####
+
+SolidAssert.enable_assertions
+
+poe = Author.create! name: "Edgar Alan Poe"
+thu = Author.create! name: "Thucydides"
+
+Work.create! title: "The Raven", author: poe
+Work.create! title: "The Black Cat", author: poe
+Work.create! title: "History of the Peloponnesian War", author: thu
+
+assert Author.count == 2
+assert Work.count == 3
+
+assert Author.find_by(name: "Edgar Alan Poe").works.size == 2
+assert Author.find_by(name: "Thucydides").works.size == 1
+
+assert UUIDTools::UUID === Author.first.id
+assert UUIDTools::UUID === Work.first.id
+assert UUIDTools::UUID === Work.first.author_id
+
+# Natural keys (UUIDs version 5) are generated deterministically.  Hence,
+# following will succeed despite that id is hardcoded:
+assert Author.find_by(id: "cb23040c-7635-58f2-a703-434c962821c1") == poe
+
+# Above UUID has been generated basing on author's name:
+uuid_namespace = UUIDTools::UUID_OID_NAMESPACE
+poe_id = UUIDTools::UUID.sha1_create(uuid_namespace, "Edgar Alan Poe")
+assert Author.find_by(id: poe_id).name == "Edgar Alan Poe"
+
+# Natural keys can be generated from more than just one field.  Also,
+# a namespace can be set for given model:
+uuid_namespace = UUIDTools::UUID.parse("a6908e1e-5493-4c55-a11d-cd8445654de6")
+raven_id = UUIDTools::UUID.sha1_create(uuid_namespace, "#{poe_id}-The Raven")
+assert Work.find_by(id: raven_id).title == "The Raven"
+
+#### PROVE THAT ASSERTIONS WERE WORKING ####
+
+begin
+  assert 1 == 2
+rescue SolidAssert::AssertionFailedError
+  puts "All OK."
+else
+  raise "Assertions do not work!"
+end

--- a/examples/registering_active_record_type.rb
+++ b/examples/registering_active_record_type.rb
@@ -1,0 +1,74 @@
+# Active UUID types can be added to Active Record's type registry.  This is
+# convenient as you can reference them in your models with a symbol.
+#
+# See Rails API docs for more information about +ActiveRecord::Type.register+:
+# https://api.rubyonrails.org/classes/ActiveRecord/Type.html#method-c-register
+
+ENV["DB"] ||= "sqlite3"
+
+require "bundler/setup"
+Bundler.require :development
+
+require "active_uuid"
+require_relative "../spec/support/0_logger"
+require_relative "../spec/support/1_db_connection"
+
+#### SCHEMA ####
+
+ActiveRecord::Schema.define do
+  create_table :authors, id: false, force: true do |t|
+    if ENV["DB"] == "postgresql"
+      t.uuid :id, primary_key: true, index: true
+    else
+      t.binary :id, limit: 16, primary_key: true, index: true
+    end
+    t.string :name
+    t.timestamps
+  end
+end
+
+#### TYPE REGISTRATION ####
+
+ActiveRecord::Type.register(
+  :uuid,
+  ActiveUUID::Type::BinaryUUID,
+)
+
+# In PostgreSQL adapter, +:uuid+ is already registered, but it can be overriden.
+ActiveRecord::Type.register(
+  :uuid,
+  ActiveUUID::Type::StringUUID,
+  adapter: :postgresql,
+  override: true,
+)
+
+#### MODELS ####
+
+class Author < ActiveRecord::Base
+  include ActiveUUID::Model
+  attribute :id, :uuid
+end
+
+#### PROOF ####
+
+SolidAssert.enable_assertions
+
+Author.create! name: "Edgar Alan Poe"
+
+assert Author.count == 1
+
+if ENV["DB"] == "postgresql"
+  assert ActiveUUID::Type::StringUUID === Author.first.type_for_attribute("id")
+else
+  assert ActiveUUID::Type::BinaryUUID === Author.first.type_for_attribute("id")
+end
+
+#### PROVE THAT ASSERTIONS WERE WORKING ####
+
+begin
+  assert 1 == 2
+rescue SolidAssert::AssertionFailedError
+  puts "All OK."
+else
+  raise "Assertions do not work!"
+end

--- a/examples/storing_uuids_as_binaries.rb
+++ b/examples/storing_uuids_as_binaries.rb
@@ -1,0 +1,88 @@
+# See README for comparison between string and binary storage.
+
+ENV["DB"] ||= "sqlite3"
+
+if ENV["DB"] == "postgresql"
+  puts <<~MESSAGE
+    Example irrelevant for selected database (#{ENV['DB']}).
+    Storing UUIDs as binaries is not compatible with PostgreSQL adapter.
+  MESSAGE
+  exit(0)
+end
+
+require "bundler/setup"
+Bundler.require :development
+
+require "active_uuid"
+require_relative "../spec/support/0_logger"
+require_relative "../spec/support/1_db_connection"
+
+#### SCHEMA ####
+
+ActiveRecord::Schema.define do
+  create_table :works, id: false, force: true do |t|
+    t.binary :id, limit: 16, primary_key: true, index: true
+    t.binary :author_id, limit: 16, index: true
+    t.string :title
+    t.timestamps
+  end
+
+  create_table :authors, id: false, force: true do |t|
+    t.binary :id, limit: 16, primary_key: true, index: true
+    t.string :name
+    t.timestamps
+  end
+end
+
+#### MODELS ####
+
+class Work < ActiveRecord::Base
+  include ActiveUUID::Model
+  attribute :id, ActiveUUID::Type::BinaryUUID.new
+  attribute :author_id, ActiveUUID::Type::BinaryUUID.new
+  belongs_to :author
+end
+
+class Author < ActiveRecord::Base
+  include ActiveUUID::Model
+  attribute :id, ActiveUUID::Type::BinaryUUID.new
+  has_many :works
+end
+
+#### PROOF ####
+
+SolidAssert.enable_assertions
+
+poe = Author.create! name: "Edgar Alan Poe"
+thu = Author.create! name: "Thucydides"
+
+Work.create! title: "The Raven", author: poe
+Work.create! title: "The Black Cat", author: poe
+Work.create! title: "History of the Peloponnesian War", author: thu
+
+assert Author.count == 2
+assert Work.count == 3
+
+assert Author.find_by(name: "Edgar Alan Poe").works.size == 2
+assert Author.find_by(name: "Thucydides").works.size == 1
+
+assert UUIDTools::UUID === Author.first.id
+assert UUIDTools::UUID === Work.first.id
+assert UUIDTools::UUID === Work.first.author_id
+
+# Version 4 means randomly generated UUID
+assert Author.first.id.version == 4
+
+# UUIDs are stored in database as 16 bytes long binaries
+raw_id = Author.first.attributes_before_type_cast["id"]
+assert raw_id.bytes.size == 16
+
+#### PROVE THAT ASSERTIONS WERE WORKING ####
+
+begin
+  assert 1 == 2
+rescue SolidAssert::AssertionFailedError
+  puts "All OK."
+else
+  raise "Assertions do not work!"
+end

--- a/examples/storing_uuids_as_strings.rb
+++ b/examples/storing_uuids_as_strings.rb
@@ -1,0 +1,81 @@
+# See README for comparison between string and binary storage.
+
+ENV["DB"] ||= "sqlite3"
+
+require "bundler/setup"
+Bundler.require :development
+
+require "active_uuid"
+require_relative "../spec/support/0_logger"
+require_relative "../spec/support/1_db_connection"
+
+#### SCHEMA ####
+
+ActiveRecord::Schema.define do
+  create_table :works, id: false, force: true do |t|
+    t.string :id, limit: 36, primary_key: true, index: true
+    t.string :author_id, limit: 36, index: true
+    t.string :title
+    t.timestamps
+  end
+
+  create_table :authors, id: false, force: true do |t|
+    t.string :id, limit: 36, primary_key: true, index: true
+    t.string :name
+    t.timestamps
+  end
+end
+
+#### MODELS ####
+
+class Work < ActiveRecord::Base
+  include ActiveUUID::Model
+  attribute :id, ActiveUUID::Type::StringUUID.new
+  attribute :author_id, ActiveUUID::Type::StringUUID.new
+  belongs_to :author
+end
+
+class Author < ActiveRecord::Base
+  include ActiveUUID::Model
+  attribute :id, ActiveUUID::Type::StringUUID.new
+  has_many :works
+end
+
+#### PROOF ####
+
+SolidAssert.enable_assertions
+
+poe = Author.create! name: "Edgar Alan Poe"
+thu = Author.create! name: "Thucydides"
+
+Work.create! title: "The Raven", author: poe
+Work.create! title: "The Black Cat", author: poe
+Work.create! title: "History of the Peloponnesian War", author: thu
+
+assert Author.count == 2
+assert Work.count == 3
+
+assert Author.find_by(name: "Edgar Alan Poe").works.size == 2
+assert Author.find_by(name: "Thucydides").works.size == 1
+
+assert UUIDTools::UUID === Author.first.id
+assert UUIDTools::UUID === Work.first.id
+assert UUIDTools::UUID === Work.first.author_id
+
+# Version 4 means randomly generated UUID
+assert Author.first.id.version == 4
+
+# UUIDs are stored in database as 36 characters long strings
+raw_id = Author.first.attributes_before_type_cast["id"]
+assert raw_id.chars.size == 36
+assert /^[-a-f0-9]*$/ =~ raw_id
+
+#### PROVE THAT ASSERTIONS WERE WORKING ####
+
+begin
+  assert 1 == 2
+rescue SolidAssert::AssertionFailedError
+  puts "All OK."
+else
+  raise "Assertions do not work!"
+end

--- a/examples/storing_uuids_natively.rb
+++ b/examples/storing_uuids_natively.rb
@@ -1,0 +1,93 @@
+# PostgreSQL natively features a UUID data type, which offerst great performance
+# without sacrificing human-readability.
+
+ENV["DB"] ||= "sqlite3"
+
+unless ENV["DB"] == "postgresql"
+  puts <<~MESSAGE
+    Example irrelevant for selected database (#{ENV['DB']}).
+    From supported databases, only PostgreSQL features
+    a UUID data type natively.
+  MESSAGE
+  exit(0)
+end
+
+require "bundler/setup"
+Bundler.require :development
+
+require "active_uuid"
+require_relative "../spec/support/0_logger"
+require_relative "../spec/support/1_db_connection"
+
+#### SCHEMA ####
+
+# PostgreSQL adapter adds #uuid column method to table definitions
+
+ActiveRecord::Schema.define do
+  create_table :works, id: false, force: true do |t|
+    t.uuid :id, primary_key: true, index: true
+    t.uuid :author_id, index: true
+    t.string :title
+    t.timestamps
+  end
+
+  create_table :authors, id: false, force: true do |t|
+    t.uuid :id, primary_key: true, index: true
+    t.string :name
+    t.timestamps
+  end
+end
+
+#### MODELS ####
+
+class Work < ActiveRecord::Base
+  include ActiveUUID::Model
+  attribute :id, ActiveUUID::Type::StringUUID.new
+  attribute :author_id, ActiveUUID::Type::StringUUID.new
+  belongs_to :author
+end
+
+class Author < ActiveRecord::Base
+  include ActiveUUID::Model
+  attribute :id, ActiveUUID::Type::StringUUID.new
+  has_many :works
+end
+
+#### PROOF ####
+
+SolidAssert.enable_assertions
+
+poe = Author.create! name: "Edgar Alan Poe"
+thu = Author.create! name: "Thucydides"
+
+Work.create! title: "The Raven", author: poe
+Work.create! title: "The Black Cat", author: poe
+Work.create! title: "History of the Peloponnesian War", author: thu
+
+assert Author.count == 2
+assert Work.count == 3
+
+assert Author.find_by(name: "Edgar Alan Poe").works.size == 2
+assert Author.find_by(name: "Thucydides").works.size == 1
+
+assert UUIDTools::UUID === Author.first.id
+assert UUIDTools::UUID === Work.first.id
+assert UUIDTools::UUID === Work.first.author_id
+
+# Version 4 means randomly generated UUID
+assert Author.first.id.version == 4
+
+# UUIDs are stored in database as 36 characters long strings
+raw_id = Author.first.attributes_before_type_cast["id"]
+assert raw_id.chars.size == 36
+assert /^[-a-f0-9]*$/ =~ raw_id
+
+#### PROVE THAT ASSERTIONS WERE WORKING ####
+
+begin
+  assert 1 == 2
+rescue SolidAssert::AssertionFailedError
+  puts "All OK."
+else
+  raise "Assertions do not work!"
+end

--- a/examples/time_based_uuids.rb
+++ b/examples/time_based_uuids.rb
@@ -1,0 +1,58 @@
+# Time-based UUIDs (version 1) store timestamp of their creation, and are
+# monotonically increasing in time.  This is very advantageous in some
+# use cases.
+
+ENV["DB"] ||= "sqlite3"
+
+require "bundler/setup"
+Bundler.require :development
+
+require "active_uuid"
+require_relative "../spec/support/0_logger"
+require_relative "../spec/support/1_db_connection"
+
+#### SCHEMA ####
+
+ActiveRecord::Schema.define do
+  create_table :authors, id: false, force: true do |t|
+    t.string :id, limit: 36, primary_key: true, index: true
+    t.string :name
+    t.timestamps
+  end
+end
+
+#### MODELS ####
+
+class Author < ActiveRecord::Base
+  include ActiveUUID::Model
+  attribute :id, ActiveUUID::Type::StringUUID.new
+  uuid_generator :time
+end
+
+#### PROOF ####
+
+SolidAssert.enable_assertions
+
+poe = Author.create! name: "Edgar Alan Poe"
+thu = Author.create! name: "Thucydides"
+fon = Author.create! name: "Jean de La Fontaine"
+kas = Author.create! name: "Jan Kasprowicz"
+
+# Version 1 means time-based UUIDs
+assert poe.id.version == 1
+
+# Timestamp can be extracted from UUID
+assert poe.id.timestamp.between? 1.minute.ago, 1.minute.from_now
+
+# Lexicographical ordering of version 1 UUIDs reflects their temporal ordering
+assert Author.all.order(id: :asc).to_a == [poe, thu, fon, kas]
+
+#### PROVE THAT ASSERTIONS WERE WORKING ####
+
+begin
+  assert 1 == 2
+rescue SolidAssert::AssertionFailedError
+  puts "All OK."
+else
+  raise "Assertions do not work!"
+end

--- a/examples/using_migrations.rb
+++ b/examples/using_migrations.rb
@@ -1,0 +1,50 @@
+# Active UUID features a convenience #uuid method, which may be used to create
+# a binary column in database migration.  Since it involves monkey patching,
+# "active_uuid/all" must be loaded.
+
+ENV["DB"] ||= "sqlite3"
+
+require "bundler/setup"
+Bundler.require :development
+
+# Note "active_uuid/all", which registers new column definitions!
+require "active_uuid/all"
+
+require_relative "../spec/support/0_logger"
+require_relative "../spec/support/1_db_connection"
+
+#### SCHEMA ####
+
+ActiveRecord::Schema.define do
+  create_table :authors, id: false, force: true do |t|
+    t.uuid :id, primary_key: true, index: true
+    t.string :name
+    t.timestamps
+  end
+end
+
+#### PROOF ####
+
+SolidAssert.enable_assertions
+
+id_column = ActiveRecord::Base.connection.columns("authors")[0]
+assert id_column.name == "id"
+
+case ENV["DB"]
+when "sqlite3"
+  assert id_column.sql_type == "binary(16)"
+when "mysql"
+  assert id_column.sql_type == "varbinary(16)"
+when "postgresql"
+  assert id_column.sql_type == "uuid"
+end
+
+#### PROVE THAT ASSERTIONS WERE WORKING ####
+
+begin
+  assert 1 == 2
+rescue SolidAssert::AssertionFailedError
+  puts "All OK."
+else
+  raise "Assertions do not work!"
+end


### PR DESCRIPTION
Write usage examples for several most common use cases:

- Storing UUIDs in various formats (strings, binaries, PostgreSQL's UUIDs).
- Having UUIDs as primary and foreign keys, using them in Rails associations.
- Using time-based UUIDs (version 1).
- Using name-based UUIDs (version 5).
- Using database migration enhancements.
