### PR TITLE
Remove an excessive option from table definition

### DIFF
--- a/examples/name_based_uuids.rb
+++ b/examples/name_based_uuids.rb
@@ -14,14 +14,14 @@ require_relative "../spec/support/1_db_connection"
 
 ActiveRecord::Schema.define do
   create_table :works, id: false, force: true do |t|
-    t.string :id, limit: 36, primary_key: true, index: true
+    t.string :id, limit: 36, primary_key: true
     t.string :author_id, limit: 36, index: true
     t.string :title
     t.timestamps
   end
 
   create_table :authors, id: false, force: true do |t|
-    t.string :id, limit: 36, primary_key: true, index: true
+    t.string :id, limit: 36, primary_key: true
     t.string :name
     t.timestamps
   end

--- a/examples/registering_active_record_type.rb
+++ b/examples/registering_active_record_type.rb
@@ -18,9 +18,9 @@ require_relative "../spec/support/1_db_connection"
 ActiveRecord::Schema.define do
   create_table :authors, id: false, force: true do |t|
     if ENV["DB"] == "postgresql"
-      t.uuid :id, primary_key: true, index: true
+      t.uuid :id, primary_key: true
     else
-      t.binary :id, limit: 16, primary_key: true, index: true
+      t.binary :id, limit: 16, primary_key: true
     end
     t.string :name
     t.timestamps

--- a/examples/storing_uuids_as_binaries.rb
+++ b/examples/storing_uuids_as_binaries.rb
@@ -21,14 +21,14 @@ require_relative "../spec/support/1_db_connection"
 
 ActiveRecord::Schema.define do
   create_table :works, id: false, force: true do |t|
-    t.binary :id, limit: 16, primary_key: true, index: true
+    t.binary :id, limit: 16, primary_key: true
     t.binary :author_id, limit: 16, index: true
     t.string :title
     t.timestamps
   end
 
   create_table :authors, id: false, force: true do |t|
-    t.binary :id, limit: 16, primary_key: true, index: true
+    t.binary :id, limit: 16, primary_key: true
     t.string :name
     t.timestamps
   end

--- a/examples/storing_uuids_as_strings.rb
+++ b/examples/storing_uuids_as_strings.rb
@@ -13,14 +13,14 @@ require_relative "../spec/support/1_db_connection"
 
 ActiveRecord::Schema.define do
   create_table :works, id: false, force: true do |t|
-    t.string :id, limit: 36, primary_key: true, index: true
+    t.string :id, limit: 36, primary_key: true
     t.string :author_id, limit: 36, index: true
     t.string :title
     t.timestamps
   end
 
   create_table :authors, id: false, force: true do |t|
-    t.string :id, limit: 36, primary_key: true, index: true
+    t.string :id, limit: 36, primary_key: true
     t.string :name
     t.timestamps
   end

--- a/examples/storing_uuids_natively.rb
+++ b/examples/storing_uuids_natively.rb
@@ -25,14 +25,14 @@ require_relative "../spec/support/1_db_connection"
 
 ActiveRecord::Schema.define do
   create_table :works, id: false, force: true do |t|
-    t.uuid :id, primary_key: true, index: true
+    t.uuid :id, primary_key: true
     t.uuid :author_id, index: true
     t.string :title
     t.timestamps
   end
 
   create_table :authors, id: false, force: true do |t|
-    t.uuid :id, primary_key: true, index: true
+    t.uuid :id, primary_key: true
     t.string :name
     t.timestamps
   end

--- a/examples/time_based_uuids.rb
+++ b/examples/time_based_uuids.rb
@@ -15,7 +15,7 @@ require_relative "../spec/support/1_db_connection"
 
 ActiveRecord::Schema.define do
   create_table :authors, id: false, force: true do |t|
-    t.string :id, limit: 36, primary_key: true, index: true
+    t.string :id, limit: 36, primary_key: true
     t.string :name
     t.timestamps
   end

--- a/examples/using_migrations.rb
+++ b/examples/using_migrations.rb
@@ -17,7 +17,7 @@ require_relative "../spec/support/1_db_connection"
 
 ActiveRecord::Schema.define do
   create_table :authors, id: false, force: true do |t|
-    t.uuid :id, primary_key: true, index: true
+    t.uuid :id, primary_key: true
     t.string :name
     t.timestamps
   end


### PR DESCRIPTION
Primary keys are always properly indexed. There is no need for adding `index: true` in column definition.