### PR TITLE
Constrain SQLite3 gem version

### DIFF
--- a/activeuuid.gemspec
+++ b/activeuuid.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   else
     s.add_development_dependency "mysql2"
     s.add_development_dependency "pg"
-    s.add_development_dependency "sqlite3"
+    s.add_development_dependency "sqlite3", "~> 1.3.6"
   end
 
   s.add_runtime_dependency "activerecord", ">= 5.0", "< 6.0"


### PR DESCRIPTION
Active Record has version constraint on SQLite3 gem.  Unfortunately, it is not specified in gemspec, but in a source file where adapter class is defined, therefore Bundler is unaware of it.  Adding an explicit version constraint in this gem's gemspec guarantees that only compatible version is installed.

It is expected that dependency version constraint will be relaxed in Active Record 5.2.3.

See this SO answer for more details: https://stackoverflow.com/a/54729071/304175.